### PR TITLE
Fix compile errors on v0.51-exaforce

### DIFF
--- a/lib/codecs/src/encoding/format/parquet.rs
+++ b/lib/codecs/src/encoding/format/parquet.rs
@@ -299,7 +299,7 @@ impl Encoder<Vec<Event>> for ParquetSerializer {
         let mut row_group_writer = parquet_writer.next_row_group()?;
         while let Some(mut column_writer) = row_group_writer.next_column()? {
             match column_writer.untyped() {
-                BoolColumnWriter(ref mut writer) => {
+                BoolColumnWriter(writer) => {
                     let desc = writer.get_descriptor().clone();
                     self.process(
                         &events,

--- a/lib/codecs/src/encoding/serializer.rs
+++ b/lib/codecs/src/encoding/serializer.rs
@@ -10,8 +10,9 @@ use super::format::{
     CefSerializerConfig, CsvSerializer, CsvSerializerConfig, GelfSerializer, GelfSerializerConfig,
     JsonSerializer, JsonSerializerConfig, LogfmtSerializer, LogfmtSerializerConfig,
     NativeJsonSerializer, NativeJsonSerializerConfig, NativeSerializer, NativeSerializerConfig,
-    ProtobufSerializer, ProtobufSerializerConfig, RawMessageSerializer, RawMessageSerializerConfig,
-    TextSerializer, TextSerializerConfig,
+    ParquetSerializer, ParquetSerializerConfig, ParquetSerializerOptions, ProtobufSerializer,
+    ProtobufSerializerConfig, RawMessageSerializer, RawMessageSerializerConfig, TextSerializer,
+    TextSerializerConfig,
 };
 #[cfg(feature = "opentelemetry")]
 use super::format::{OtlpSerializer, OtlpSerializerConfig};
@@ -256,7 +257,7 @@ impl SerializerConfig {
             ))),
             SerializerConfig::Avro { .. }
             | SerializerConfig::Csv(..)
-            | SerializerConfig::Gelf
+            | SerializerConfig::Gelf(..)
             | SerializerConfig::Json(..)
             | SerializerConfig::Logfmt
             | SerializerConfig::Native


### PR DESCRIPTION
## Summary
Unblocks the `Publish` workflow on `v0.51-exaforce`, which has been red on every push since Nov 2025.

Three mechanical fixes, all in `lib/codecs`:

1. `encoding/serializer.rs` — add `ParquetSerializer`, `ParquetSerializerConfig`, `ParquetSerializerOptions` to the `use super::format::{ ... }` block. Resolves 7 E0412/E0433 errors (lines 124/255/326/350/624/627/628).
2. `encoding/serializer.rs:260` — `SerializerConfig::Gelf` → `SerializerConfig::Gelf(..)`. The enum defines `Gelf(GelfSerializerConfig)` (tuple variant); the match arm in `build_batched()` was using unit-variant syntax. Resolves E0532.
3. `encoding/format/parquet.rs:302` — drop `ref mut` from `BoolColumnWriter(ref mut writer)`. Rust 2024 match-ergonomics disallows explicit `ref mut` when default binding mode is already `move`. The sibling arms (`Int64ColumnWriter(writer)`, etc.) already use the bare form.

Local verification: `cargo check -p codecs` — green.